### PR TITLE
0.1.0

### DIFF
--- a/octoprint_backupscheduler/__init__.py
+++ b/octoprint_backupscheduler/__init__.py
@@ -216,13 +216,12 @@ class BackupschedulerPlugin(octoprint.plugin.SettingsPlugin,
 __plugin_name__ = "Backup Scheduler"
 __plugin_pythoncompat__ = ">=2.7,<4"
 
-# to be added back in at a later date once time has passed for version 0.0.6 to distribute.
-# def __plugin_check__():
-# 	from octoprint.util.version import is_octoprint_compatible
-# 	compatible = is_octoprint_compatible(">=1.6.0")
-# 	if not compatible:
-# 		logging.getLogger(__name__).info("Backup Scheduler requires OctoPrint 1.6.0+")
-# 	return compatible
+def __plugin_check__():
+	from octoprint.util.version import is_octoprint_compatible
+	compatible = is_octoprint_compatible(">=1.6.0")
+	if not compatible:
+		logging.getLogger(__name__).info("Backup Scheduler requires OctoPrint 1.6.0+")
+	return compatible
 
 def __plugin_load__():
 	global __plugin_implementation__

--- a/octoprint_backupscheduler/__init__.py
+++ b/octoprint_backupscheduler/__init__.py
@@ -156,7 +156,7 @@ class BackupschedulerPlugin(octoprint.plugin.SettingsPlugin,
 				return
 
 		instance_name = self._settings.global_get(["appearance", "name"]) or "octoprint"
-		backup_filename = "{}-{}-{:%Y%m%d%H%M%S}.zip".format(instance_name, backup_type.replace("_backups", ""), datetime.now())
+		backup_filename = "{}-{}-{:%Y%m%d-%H%M%S}.zip".format(instance_name, backup_type.replace("_backups", ""), datetime.now())
 		self._logger.debug("Performing {} with exclusions: {} as {}.".format(backup_type, exclusions, backup_filename))
 		self.backup_helpers["create_backup"](exclude=exclusions, filename=backup_filename)
 		completed_backups = self._settings.get([backup_type])

--- a/octoprint_backupscheduler/__init__.py
+++ b/octoprint_backupscheduler/__init__.py
@@ -216,12 +216,13 @@ class BackupschedulerPlugin(octoprint.plugin.SettingsPlugin,
 __plugin_name__ = "Backup Scheduler"
 __plugin_pythoncompat__ = ">=2.7,<4"
 
-def __plugin_check__():
-	from octoprint.util.version import is_octoprint_compatible
-	compatible = is_octoprint_compatible(">=1.6.0")
-	if not compatible:
-		logging.getLogger(__name__).info("Backup Scheduler requires OctoPrint 1.6.0+")
-	return compatible
+# to be added back in at a later date once time has passed for version 0.0.6 to distribute.
+# def __plugin_check__():
+# 	from octoprint.util.version import is_octoprint_compatible
+# 	compatible = is_octoprint_compatible(">=1.6.0")
+# 	if not compatible:
+# 		logging.getLogger(__name__).info("Backup Scheduler requires OctoPrint 1.6.0+")
+# 	return compatible
 
 def __plugin_load__():
 	global __plugin_implementation__

--- a/octoprint_backupscheduler/__init__.py
+++ b/octoprint_backupscheduler/__init__.py
@@ -7,7 +7,7 @@ import octoprint.plugin
 from . import schedule
 import threading
 from datetime import datetime
-from octoprint.util import RepeatedTimer
+from octoprint.util import RepeatedTimer, version
 
 
 class BackupschedulerPlugin(octoprint.plugin.SettingsPlugin,
@@ -182,8 +182,7 @@ class BackupschedulerPlugin(octoprint.plugin.SettingsPlugin,
 	# ~~ Softwareupdate hook
 
 	def get_update_information(self):
-		return dict(
-			backupscheduler=dict(
+		data = dict(
 				displayName="Backup Scheduler",
 				displayVersion=self._plugin_version,
 
@@ -205,7 +204,13 @@ class BackupschedulerPlugin(octoprint.plugin.SettingsPlugin,
 				# update method: pip
 				pip="https://github.com/jneilliii/OctoPrint-BackupScheduler/archive/{target_version}.zip"
 			)
-		)
+
+		# if octoprint version is less than 1.6.0, lock update check to specific branch
+		if not version.is_octoprint_compatible(">=1.6.0"):
+			data['type'] = 'github_commit'
+			data['branch'] = '0.0.6'
+
+		return dict(backupscheduler=data)
 
 
 __plugin_name__ = "Backup Scheduler"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_backupscheduler"
 plugin_name = "Backup Scheduler"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.0rc1"
+plugin_version = "0.1.0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_backupscheduler"
 plugin_name = "Backup Scheduler"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.0.5"
+plugin_version = "0.1.0rc1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
* Convert to backup helpers available in OctoPrint 1.6.0+ to avoid use of the deprecated Global API key.
* added custom names for each of the various backup types for easier identification. files will be named in the format `{appearance > title}-{backup_type}-{timestamp}.zip`