### PR TITLE
0.0.6

### DIFF
--- a/octoprint_backupscheduler/__init__.py
+++ b/octoprint_backupscheduler/__init__.py
@@ -7,7 +7,7 @@ import requests
 import threading
 import json
 from datetime import datetime
-from octoprint.util import RepeatedTimer
+from octoprint.util import RepeatedTimer, version
 
 
 class BackupschedulerPlugin(octoprint.plugin.SettingsPlugin,
@@ -184,8 +184,7 @@ class BackupschedulerPlugin(octoprint.plugin.SettingsPlugin,
 	# ~~ Softwareupdate hook
 
 	def get_update_information(self):
-		return dict(
-			backupscheduler=dict(
+		data = dict(
 				displayName="Backup Scheduler",
 				displayVersion=self._plugin_version,
 
@@ -207,7 +206,13 @@ class BackupschedulerPlugin(octoprint.plugin.SettingsPlugin,
 				# update method: pip
 				pip="https://github.com/jneilliii/OctoPrint-BackupScheduler/archive/{target_version}.zip"
 			)
-		)
+
+		# if octoprint version is less than 1.6.0, lock update check to specific branch
+		if not version.is_octoprint_compatible(">=1.6.0"):
+			data['type'] = 'github_commit'
+			data['branch'] = '0.0.6'
+
+		return dict(backupscheduler=data)
 
 
 __plugin_name__ = "Backup Scheduler"

--- a/octoprint_backupscheduler/templates/backupscheduler_settings.jinja2
+++ b/octoprint_backupscheduler/templates/backupscheduler_settings.jinja2
@@ -1,4 +1,5 @@
 <h3>{{ _('Backup Scheduler') }} <small>{{ _('Version') }}: <span data-bind="text: settingsViewModel.settings.plugins.backupscheduler.installed_version"></span></small></h3>
+<div class="well alert-danger" data-bind="visible: parseInt(VERSION.split('.')[1])<6">OctoPrint versions older than 1.6.0 will no longer get updates for this plugin.</div>
 <div class="row-fluid">
     <div class="row-fluid"><strong>{{ _('Schedule Backups') }}</strong></div>
     <div class="control-group">

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_backupscheduler"
 plugin_name = "Backup Scheduler"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.0.5"
+plugin_version = "0.0.6"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
lock updates in prep for change to backup helpers only available in OctoPrint 1.6.0+